### PR TITLE
Reference definition

### DIFF
--- a/capitains.rng
+++ b/capitains.rng
@@ -2,7 +2,8 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0" ns="http://purl.org/capitains/ns/1.0#"
   datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
   xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:dct="http://purl.org/dc/terms/">
   <!-- je restructurerais bien le schéma en listant les patterns par NS, puis regroupement par ref dans le pattern collection -->
   <!-- idem, il faut mieux documenter et inscrire dans le schéma les 2 choix de structuration: élément capitains:collection renseigné OU lien vers fichier de méta -->
   <start>
@@ -306,6 +307,30 @@
       </choice>
     </element>
   </define>
+  <define name="dct.isReferencedBy">
+    <element name="dct:isReferencedBy">
+      <a:documentation xml:lang="eng"> A related resource that references, cites, or otherwise points to the described resource. </a:documentation>
+      <ref name="identifier.att"></ref>
+      <optional>
+        <ref name="lang-att"/>
+      </optional>
+      <choice>
+        <text/>
+      </choice>
+    </element>
+  </define>
+  <define name="dct.references">
+    <element name="dct:references">
+      <a:documentation xml:lang="eng"> A related resource that is referenced, cited, or otherwise pointed to by the described resource. </a:documentation>
+      <ref name="identifier.att"></ref>
+      <optional>
+        <ref name="lang-att"/>
+      </optional>
+      <choice>
+        <text/>
+      </choice>
+    </element>
+  </define>
   <define name="lang-att">
     <attribute>
       <a:documentation xml:lang="eng">Language in which the current node is
@@ -327,6 +352,8 @@
             <except>
               <nsName ns="http://purl.org/dc/elements/1.1/"/>
               <nsName ns="http://purl.org/ns/capitains"/>
+              <name ns="http://purl.org/dc/terms/">isReferencedBy</name>
+              <name ns="http://purl.org/dc/terms/">references</name>
             </except>
           </anyName>
           <optional>
@@ -334,6 +361,12 @@
           </optional>
           <text/>
         </element>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="dct.isReferencedBy"/>
+      </zeroOrMore>
+      <zeroOrMore>
+        <ref name="dct.references"/>
       </zeroOrMore>
     </element>
   </define>


### PR DESCRIPTION
The purpose here is to define an element that can serve as a pointer between and among texts in a way similar to ti:commentary. The two proposed elements (dct:references and dct:isReferencedBy) are broader in definition than ti:commentary but also encompass it. We would use this internally to describe which formulae contain words that are in our e-lexicon with `dct:isReferenceBy` elements in the metadata for the e-lexicon texts.
I am happy to hear feedback about whether such an element should be defined in the RNG and, if so, whether this is the best way to do it.